### PR TITLE
Update Growth Factor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 test_al_get: test/test_al_get.c src/arraylist.c
 	mkdir -p bin
-	gcc -o bin/a.out test/test_al_get.c src/arraylist.c
+	gcc -o bin/a.out test/test_al_get.c src/arraylist.c -lm
 
 test_al_add: test/test_al_add.c src/arraylist.c
 	mkdir -p bin
-	gcc -o bin/a.out test/test_al_add.c src/arraylist.c
+	gcc -o bin/a.out test/test_al_add.c src/arraylist.c -lm
 
 test_al_remove: test/test_al_remove.c src/arraylist.c
 	mkdir -p bin
-	gcc -o bin/a.out test/test_al_remove.c src/arraylist.c
+	gcc -o bin/a.out test/test_al_remove.c src/arraylist.c -lm
 
 test_al_add_end: test/test_al_add_end.c src/arraylist.c
 	mkdir -p bin
-	gcc -o bin/a.out test/test_al_add_end.c src/arraylist.c
+	gcc -o bin/a.out test/test_al_add_end.c src/arraylist.c -lm

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Dynamic array for holding integers.
 
 - al_get: Return the element held at a specified index. Error if no element exists at the index.
 
-- al_add: Add an element to a specified index, doubling the capacity of the list if `al_size` is about to exceed the list's capacity. If an element is added to an already occupied index, each element, starting with the occupying element, is shifted to the right, then the new element is added.
+- al_add: Add an element to a specified index, increasing the capacity to 1.5 times its current capacity if `al_size` is about to exceed the list's capacity. If an element is added to an already occupied index, each element, starting with the occupying element, is shifted to the right, then the new element is added.
 
-- al_remove: Remove an element at a specified index, halving the size of the list if all of the following hold true:
+- al_remove: Remove an element at a specified index, dividing the capacity by 1.5 if all of the following hold true:
   - `al_size` falls below 30% of the list's capacity
   - the capacity of the list is greater than its default initial capacity (10)
-  - there are no elements in the portion of the list that will be lost if the list is halved
+  - there are no elements in the portion of the list that will be lost when the list is contracted
 
 - al_del: Deallocate the arraylist.
 

--- a/src/arraylist.c
+++ b/src/arraylist.c
@@ -1,9 +1,11 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 #include "../include/arraylist.h"
 #include "../include/_arraylist.h"
 
 #define AL_INIT_CAPACITY 10
+#define GROWTH_FACTOR 1.5
 
 static Position *_pos_init() {
     Position *p = malloc(sizeof *p);
@@ -18,25 +20,25 @@ static Position *_pos_init() {
 
 /* Doubles the size of al->list */
 static void _al_expand(ArrayList *al) {
-    al->list = realloc(al->list, sizeof *al->list * al->_capacity * 2);
+    al->list = realloc(al->list, sizeof *al->list * floor(al->_capacity * GROWTH_FACTOR));
     if (al->list == NULL) {
         fprintf(stderr, "Failed to expand ArrayList\n");
         exit(EXIT_FAILURE);
     }
-    for (size_t i = al->_capacity; i < al->_capacity * 2; i++) {
+    for (size_t i = al->_capacity; i < floor(al->_capacity * GROWTH_FACTOR); i++) {
         *(al->list + i) = _pos_init();
     }
-    al->_capacity *= 2;
+    al->_capacity = floor(al->_capacity * GROWTH_FACTOR);
 }
 
 /* Halves the size of al->list */
 static void _al_shrink(ArrayList *al) {
-    al->list = realloc(al->list, sizeof *al->list * al->_capacity / 2);
+    al->list = realloc(al->list, sizeof *al->list * ceil(al->_capacity / GROWTH_FACTOR));
     if (al->list == NULL) {
         fprintf(stderr, "Failed to shrink ArrayList\n");
         exit(EXIT_FAILURE);
     }
-    al->_capacity /= 2;
+    al->_capacity = ceil(al->_capacity / GROWTH_FACTOR);
 }
 
 /* Return the rightmost non-empty index or zero if ArrayList is empty */
@@ -134,7 +136,7 @@ int al_remove(ArrayList *al, int index) {
     al->size--;
     if (al_size(al) < 0.3 * al->_capacity && al->_capacity > 10) {
         int can_shrink = 1;
-        for (int i = al->_capacity / 2; i < al->_capacity; i++) {
+        for (int i = ceil(al->_capacity / 2.0); i < al->_capacity; i++) {
             if (!(*(al->list + i))->is_empty) {
                 can_shrink = 0;
                 break;


### PR DESCRIPTION
Decrease the growth factor from 2 to 1.5.

When the ArrayList needs more space than it currently has, it copies its contents to a larger region of memory, and frees the original block. This leaves a hole that increases in size (assuming subsequent allocations are contiguous), each time the array expands.

With a growth factor of 2, and an initial capacity of 10, a sequence of expansions looks as follows:

| Capacity | Hole |
|-------------|--------|
| 10           | 0      |
| 20           | 10    |
| 40           | 30    |
| 80           | 70    |
| 160         | 150  |

The hole left behind is never large enough to satisfy a new allocation. 

With a growth factor of 1.5:

| Capacity | Hole |
|-------------|--------|
| 10           | 0      |
| 15           | 10    |
| 22           | 35    |
| 33           | 2      |

On the 4th allocation, the hole left behind from the previous allocation can be used to satisfy the request.